### PR TITLE
Remove infra points

### DIFF
--- a/LTS/data/LTS/effects.ruleset
+++ b/LTS/data/LTS/effects.ruleset
@@ -4735,6 +4735,5 @@ reqs  =
     { "type",                 "name",         "range",  "present"
       "NationalIntelligence", "Mood",         "Player", FALSE
       "NationalIntelligence", "History",      "Player", FALSE
-      "NationalIntelligence", "Infra Points", "Player", FALSE
       "DiplRel",              "Has embassy",  "Local",  TRUE
     }

--- a/LTT/data/LTT/effects.ruleset
+++ b/LTT/data/LTT/effects.ruleset
@@ -4747,6 +4747,5 @@ reqs  =
     { "type",                 "name",         "range",  "present"
       "NationalIntelligence", "Mood",         "Player", FALSE
       "NationalIntelligence", "History",      "Player", FALSE
-      "NationalIntelligence", "Infra Points", "Player", FALSE
       "DiplRel",              "Has embassy",  "Local",  TRUE
     }

--- a/LTX/data/LTX/effects.ruleset
+++ b/LTX/data/LTX/effects.ruleset
@@ -5714,7 +5714,6 @@ reqs  =
     { "type",                 "name",         "range",  "present"
       "NationalIntelligence", "Mood",         "Player", FALSE
       "NationalIntelligence", "History",      "Player", FALSE
-      "NationalIntelligence", "Infra Points", "Player", FALSE
       "DiplRel",              "Has embassy",  "Local",  TRUE
     }
 	

--- a/Royale/data/Royale/effects.ruleset
+++ b/Royale/data/Royale/effects.ruleset
@@ -5151,7 +5151,6 @@ reqs  =
     { "type",                 "name",         "range",  "present"
       "NationalIntelligence", "Mood",         "Player", FALSE
       "NationalIntelligence", "History",      "Player", FALSE
-      "NationalIntelligence", "Infra Points", "Player", FALSE
       "DiplRel",              "Has embassy",  "Local",  TRUE
     }
 	


### PR DESCRIPTION
Support for infra points has been removed from Freeciv21 (longturn/freeciv21#1937).

I noticed this while trying to load LTT and LTX in the latest Freeciv21 client as a single player game. However, loading the ruleset still fails, probably because of these messages:

```
[warning] freeciv21-client - The server sent an invalid or unknown requirement.
[warning] freeciv21-client - The server sent an invalid or unknown requirement.
```