### PR TITLE
Rename "You're Fired" action to "Disband Unit"

### DIFF
--- a/LTS/data/LTS/game.ruleset
+++ b/LTS/data/LTS/game.ruleset
@@ -430,8 +430,8 @@ ui_name_help_wonder = _("Help %sbuild Wonder%s")
 ; /* TRANS: Rec_ycle Unit (100% chance of success). */
 ui_name_recycle_unit = _("Rec%sycle Unit%s")
 
-; /* TRANS: _You're Fired (100% chance of success). */
-ui_name_disband_unit = _("%sYou're Fired%s")
+; /* TRANS: _Disband Unit (100% chance of success). */
+ui_name_disband_unit = _("%sDisband Unit%s")
 
 ; /* TRANS: _Capture Units (100% chance of success). */
 ui_name_capture_units = _("%sCapture Units%s")

--- a/LTT/data/LTT/game.ruleset
+++ b/LTT/data/LTT/game.ruleset
@@ -430,8 +430,8 @@ ui_name_help_wonder = _("Help %sbuild Wonder%s")
 ; /* TRANS: Rec_ycle Unit (100% chance of success). */
 ui_name_recycle_unit = _("Rec%sycle Unit%s")
 
-; /* TRANS: _You're Fired (100% chance of success). */
-ui_name_disband_unit = _("%sYou're Fired%s")
+; /* TRANS: _Disband Unit (100% chance of success). */
+ui_name_disband_unit = _("%sDisband Unit%s")
 
 ; /* TRANS: _Capture Units (100% chance of success). */
 ui_name_capture_units = _("%sCapture Units%s")

--- a/LTT2/data/LTT2/game.ruleset
+++ b/LTT2/data/LTT2/game.ruleset
@@ -430,8 +430,8 @@ ui_name_help_wonder = _("Help %sbuild Wonder%s")
 ; /* TRANS: Rec_ycle Unit (100% chance of success). */
 ui_name_recycle_unit = _("Rec%sycle Unit%s")
 
-; /* TRANS: _You're Fired (100% chance of success). */
-ui_name_disband_unit = _("%sYou're Fired%s")
+; /* TRANS: _Disband Unit (100% chance of success). */
+ui_name_disband_unit = _("%sDisband Unit%s")
 
 ; /* TRANS: _Capture Units (100% chance of success). */
 ui_name_capture_units = _("%sCapture Units%s")

--- a/LTX/data/LTX/game.ruleset
+++ b/LTX/data/LTX/game.ruleset
@@ -419,8 +419,8 @@ ui_name_help_wonder = _("Help %sbuild Wonder%s")
 ; /* TRANS: Rec_ycle Unit (100% chance of success). */
 ui_name_recycle_unit = _("Rec%sycle Unit%s")
 
-; /* TRANS: _You're Fired (100% chance of success). */
-ui_name_disband_unit = _("%sYou're Fired%s")
+; /* TRANS: _Disband Unit (100% chance of success). */
+ui_name_disband_unit = _("%sDisband Unit%s")
 
 ; /* TRANS: _Capture Units (100% chance of success). */
 ui_name_capture_units = _("%sCapture Units%s")

--- a/Royale/data/Royale/game.ruleset
+++ b/Royale/data/Royale/game.ruleset
@@ -430,8 +430,8 @@ ui_name_help_wonder = _("Help %sbuild Wonder%s")
 ; /* TRANS: Rec_ycle Unit (100% chance of success). */
 ui_name_recycle_unit = _("Rec%sycle Unit%s")
 
-; /* TRANS: _You're Fired (100% chance of success). */
-ui_name_disband_unit = _("%sYou're Fired%s")
+; /* TRANS: _Disband Unit (100% chance of success). */
+ui_name_disband_unit = _("%sDisband Unit%s")
 
 ; /* TRANS: _Capture Units (100% chance of success). */
 ui_name_capture_units = _("%sCapture Units%s")


### PR DESCRIPTION
“You're Fired” was renamed "Disband Unit" in Freeciv21. This commit makes the corresponding renaming in the Longturn rulesets.

The renaming was done with the following command line:

    find . -type f -name '*.ruleset' \
        | xargs -n 1 sed -i "" -e "s/You're Fired/Disband Unit/"

Closes #22 